### PR TITLE
Move mixins away from overrides

### DIFF
--- a/src/main/java/draylar/identity/api/model/EntityUpdaters.java
+++ b/src/main/java/draylar/identity/api/model/EntityUpdaters.java
@@ -66,7 +66,7 @@ public class EntityUpdaters {
         });
 
         EntityUpdaters.register(EntityType.PARROT, (player, parrot) -> {
-            if(player.isOnGround() && ((NearbySongAccessor) player).isNearbySongPlaying()) {
+            if(player.isOnGround() && ((NearbySongAccessor) player).identity_isNearbySongPlaying()) {
                 parrot.setNearbySongPlaying(player.getBlockPos(), true);
                 parrot.setSitting(true);
                 parrot.setOnGround(true);

--- a/src/main/java/draylar/identity/cca/IdentityComponent.java
+++ b/src/main/java/draylar/identity/cca/IdentityComponent.java
@@ -60,7 +60,7 @@ public class IdentityComponent implements AutoSyncedComponent, ServerTickingComp
         this.identity = identity;
 
         // refresh entity hitbox dimensions
-        ((DimensionsRefresher) player).refresh();
+        ((DimensionsRefresher) player).identity_refreshDimensions();
 
         // Identity is valid and scaling health is on; set entity's max health and current health to reflect identity.
         if(identity != null && Identity.CONFIG.scalingHealth) {
@@ -195,7 +195,7 @@ public class IdentityComponent implements AutoSyncedComponent, ServerTickingComp
         // set identity to null (no identity) if the entity id is "minecraft:empty"
         if(tag.getString("id").equals("minecraft:empty")) {
             this.identity = null;
-            ((DimensionsRefresher) player).refresh();
+            ((DimensionsRefresher) player).identity_refreshDimensions();
         }
 
         // if entity type was valid, deserialize entity data from tag
@@ -208,7 +208,7 @@ public class IdentityComponent implements AutoSyncedComponent, ServerTickingComp
                     identity = (LivingEntity) type.get().create(player.world);
 
                     // refresh player dimensions/hitbox on client
-                    ((DimensionsRefresher) player).refresh();
+                    ((DimensionsRefresher) player).identity_refreshDimensions();
                 }
 
                 identity.fromTag(entityTag);

--- a/src/main/java/draylar/identity/impl/DimensionsRefresher.java
+++ b/src/main/java/draylar/identity/impl/DimensionsRefresher.java
@@ -1,5 +1,5 @@
 package draylar.identity.impl;
 
 public interface DimensionsRefresher {
-    void refresh();
+    void identity_refreshDimensions();
 }

--- a/src/main/java/draylar/identity/impl/NearbySongAccessor.java
+++ b/src/main/java/draylar/identity/impl/NearbySongAccessor.java
@@ -4,5 +4,5 @@ package draylar.identity.impl;
  * Duck interface for accessing information about nearby playing music in {@link draylar.identity.mixin.PlayerEntityMixin}.
  */
 public interface NearbySongAccessor {
-    boolean isNearbySongPlaying();
+    boolean identity_isNearbySongPlaying();
 }

--- a/src/main/java/draylar/identity/mixin/EntityMixin.java
+++ b/src/main/java/draylar/identity/mixin/EntityMixin.java
@@ -60,7 +60,7 @@ public abstract class EntityMixin implements DimensionsRefresher {
     }
 
     @Override
-    public void refresh() {
+    public void identity_refreshDimensions() {
         EntityDimensions currentDimensions = this.dimensions;
         EntityPose entityPose = this.getPose();
         EntityDimensions newDimensions = this.getDimensions(entityPose);

--- a/src/main/java/draylar/identity/mixin/InGameHudMixin.java
+++ b/src/main/java/draylar/identity/mixin/InGameHudMixin.java
@@ -9,25 +9,29 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.tag.FluidTags;
 import net.minecraft.tag.Tag;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(InGameHud.class)
-public class InGameHudMixin {
+public abstract class InGameHudMixin {
 
-    @Redirect(
+    @Shadow protected abstract PlayerEntity getCameraPlayer();
+
+    @ModifyArg(
             method = "renderStatusBars",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;isSubmergedIn(Lnet/minecraft/tag/Tag;)Z")
     )
-    private boolean shouldRenderBreath(PlayerEntity player, Tag<Fluid> tag) {
+    private Tag<Fluid> shouldRenderBreath(Tag<Fluid> tag) {
+        PlayerEntity player = this.getCameraPlayer();
         LivingEntity identity = Components.CURRENT_IDENTITY.get(player).getIdentity();
 
         if(identity != null) {
             if(Identity.isAquatic(identity) && player.isSubmergedIn(FluidTags.WATER)) {
-                return false;
+                return FluidTags.LAVA;    // will cause isSubmergedIn to return false, preventing air render
             }
         }
 
-        return player.isSubmergedIn(FluidTags.WATER);
+        return tag;
     }
 }

--- a/src/main/java/draylar/identity/mixin/LivingEntityMixin.java
+++ b/src/main/java/draylar/identity/mixin/LivingEntityMixin.java
@@ -4,6 +4,8 @@ import draylar.identity.Identity;
 import draylar.identity.cca.UnlockedIdentitysComponent;
 import draylar.identity.registry.Components;
 import draylar.identity.registry.EntityTags;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -16,6 +18,7 @@ import net.minecraft.entity.passive.BatEntity;
 import net.minecraft.entity.passive.DolphinEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -32,7 +35,7 @@ public abstract class LivingEntityMixin extends Entity {
 
     @Shadow public abstract boolean hasStatusEffect(StatusEffect effect);
 
-    private LivingEntityMixin(EntityType<?> type, World world) {
+    protected LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
     }
 
@@ -177,7 +180,7 @@ public abstract class LivingEntityMixin extends Entity {
 
     @Inject(
             method = "getMaxHealth",
-            at = @At("RETURN"),
+            at = @At("HEAD"),
             cancellable = true
     )
     private void modifyMaxHealth(CallbackInfoReturnable<Float> cir) {
@@ -192,16 +195,34 @@ public abstract class LivingEntityMixin extends Entity {
         }
     }
 
-//
-//    @Inject(
-//            method = "isClimbing",
-//            at = @At(
-//                    value = "INVOKE",
-//                    target = "Lnet/minecraft/block/BlockState;getBlock()Lnet/minecraft/block/Block;"),
-//            cancellable = true,
-//            locals = LocalCapture.CAPTURE_FAILHARD
-//    )
-//    public void allowSpiderClimbing(CallbackInfoReturnable<Boolean> cir, BlockState state) {
-//        cir.setReturnValue(!state.isAir());
-//    }
+    @Inject(method = "hurtByWater", at = @At("HEAD"), cancellable = true)
+    protected void identity_hurtByWater(CallbackInfoReturnable<Boolean> cir) {
+        // NO-OP
+    }
+
+    @Inject(method = "canBreatheInWater", at = @At("HEAD"), cancellable = true)
+    protected void identity_canBreatheInWater(CallbackInfoReturnable<Boolean> cir) {
+        // NO-OP
+    }
+
+    @Environment(EnvType.CLIENT)
+    @Inject(method = "setNearbySongPlaying", at = @At("RETURN"))
+    protected void identity_setNearbySongPlaying(BlockPos songPosition, boolean playing, CallbackInfo ci) {
+        // NO-OP
+    }
+
+    @Inject(method = "isUndead", at = @At("HEAD"), cancellable = true)
+    protected void identity_isUndead(CallbackInfoReturnable<Boolean> cir) {
+        // NO-OP
+    }
+
+
+    @Inject(
+            method = "isClimbing",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    protected void identity_allowSpiderClimbing(CallbackInfoReturnable<Boolean> cir) {
+        // NO-OP
+    }
 }

--- a/src/main/java/draylar/identity/mixin/TrackTargetGoalMixin.java
+++ b/src/main/java/draylar/identity/mixin/TrackTargetGoalMixin.java
@@ -1,0 +1,22 @@
+package draylar.identity.mixin;
+
+import net.minecraft.entity.ai.goal.TrackTargetGoal;
+import net.minecraft.entity.mob.MobEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TrackTargetGoal.class)
+public abstract class TrackTargetGoalMixin {
+    @Shadow @Final protected MobEntity mob;
+
+    @Shadow public abstract void stop();
+
+    @Inject(method = "shouldContinue", at = @At("RETURN"), cancellable = true)
+    protected void identity_shouldContinue(CallbackInfoReturnable<Boolean> cir) {
+        // NO-OP
+    }
+}

--- a/src/main/resources/identity.mixins.json
+++ b/src/main/resources/identity.mixins.json
@@ -16,6 +16,7 @@
     "PlayerAdvancementTrackerMixin",
     "PlayerEntityMixin",
     "ServerPlayerEntityMixin",
+    "TrackTargetGoalMixin",
     "VillagerEntityMixin",
     "VillagerHostilesSensorMixin",
     "WitherEntityMixin",


### PR DESCRIPTION
Identity is currently incompatible with virtually every entity mixin in existence, due to the common use of `@Override`. This PR replaces most incompatible mixins with an injection-based variant.

This notably fixes #50 