### PR TITLE
add gitignore from fabric example mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# gradle
+
+.gradle/
+build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
+# macos
+
+*.DS_Store
+
+# fabric
+
+run/


### PR DESCRIPTION
It's quite annoying without a `.gitignore` file, because there are thousands of untracked file shown in the version control pannel after I ran build command.