### PR TITLE
Use @ModifyVariable instead of @Redirect for water creature swim boost

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.17.1+build.61
 loader_version=0.11.7
 
 # Mod Properties
-mod_version=1.15.0
+mod_version=1.15.1
 maven_group=draylar
 archives_base_name=identity
 

--- a/src/main/java/draylar/identity/mixin/LivingEntityMixin.java
+++ b/src/main/java/draylar/identity/mixin/LivingEntityMixin.java
@@ -23,6 +23,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -30,9 +31,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity {
 
-    @Shadow protected abstract int getNextAirOnLand(int air);
+    @Shadow
+    protected abstract int getNextAirOnLand(int air);
 
-    @Shadow public abstract boolean hasStatusEffect(StatusEffect effect);
+    @Shadow
+    public abstract boolean hasStatusEffect(StatusEffect effect);
 
     protected LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
@@ -47,7 +50,7 @@ public abstract class LivingEntityMixin extends Entity {
         EntityType<?> thisType = this.getType();
 
         // check if attacker is a player to grant identity
-        if(attacker instanceof PlayerEntity) {
+        if (attacker instanceof PlayerEntity) {
             IdentityGranting.grantByAttack((PlayerEntity) attacker, thisType);
         }
     }
@@ -76,7 +79,7 @@ public abstract class LivingEntityMixin extends Entity {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z", ordinal = 0)
     )
     private boolean slowFall(LivingEntity livingEntity, StatusEffect effect) {
-        if((Object) this instanceof PlayerEntity) {
+        if ((Object) this instanceof PlayerEntity) {
             LivingEntity identity = Components.CURRENT_IDENTITY.get(this).getIdentity();
 
             if (identity != null) {
@@ -89,21 +92,18 @@ public abstract class LivingEntityMixin extends Entity {
         return this.hasStatusEffect(StatusEffects.SLOW_FALLING);
     }
 
-    @Redirect(
-            method = "travel",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z", ordinal = 1)
-    )
-    private boolean applyWaterCreatureSwimSpeedBoost(LivingEntity livingEntity, StatusEffect effect) {
-        if((Object) this instanceof PlayerEntity) {
+    @ModifyVariable(method = "travel", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z", ordinal = 1), ordinal = 0)
+    public float applyWaterCreatureSwimSpeedBoost(float j) {
+        if ((Object) this instanceof PlayerEntity) {
             LivingEntity identity = Components.CURRENT_IDENTITY.get(this).getIdentity();
 
             // Apply 'Dolphin's Grace' status effect benefits if the player's Identity is a water creature
             if (identity instanceof WaterCreatureEntity) {
-                return true;
+                return .96f;
             }
         }
 
-        return this.hasStatusEffect(StatusEffects.DOLPHINS_GRACE);
+        return j;
     }
 
     @Inject(
@@ -112,7 +112,7 @@ public abstract class LivingEntityMixin extends Entity {
             cancellable = true
     )
     private void handleFallDamage(float fallDistance, float damageMultiplier, DamageSource damageSource, CallbackInfoReturnable<Boolean> cir) {
-        if((Object) this instanceof PlayerEntity) {
+        if ((Object) this instanceof PlayerEntity) {
             LivingEntity identity = Components.CURRENT_IDENTITY.get(this).getIdentity();
 
             if (identity != null) {
@@ -137,7 +137,7 @@ public abstract class LivingEntityMixin extends Entity {
             cancellable = true
     )
     private void returnHasNightVision(StatusEffect effect, CallbackInfoReturnable<Boolean> cir) {
-        if((Object) this instanceof PlayerEntity) {
+        if ((Object) this instanceof PlayerEntity) {
             if (effect.equals(StatusEffects.NIGHT_VISION)) {
                 LivingEntity identity = Components.CURRENT_IDENTITY.get(this).getIdentity();
 
@@ -155,7 +155,7 @@ public abstract class LivingEntityMixin extends Entity {
             cancellable = true
     )
     private void returnNightVisionInstance(StatusEffect effect, CallbackInfoReturnable<StatusEffectInstance> cir) {
-        if((Object) this instanceof PlayerEntity) {
+        if ((Object) this instanceof PlayerEntity) {
             if (effect.equals(StatusEffects.NIGHT_VISION)) {
                 LivingEntity identity = Components.CURRENT_IDENTITY.get(this).getIdentity();
 
@@ -173,7 +173,7 @@ public abstract class LivingEntityMixin extends Entity {
             cancellable = true
     )
     private void modifyMaxHealth(CallbackInfoReturnable<Float> cir) {
-        if(Identity.CONFIG.scalingHealth) {
+        if (Identity.CONFIG.scalingHealth) {
             if ((Object) this instanceof PlayerEntity) {
                 LivingEntity identity = Components.CURRENT_IDENTITY.get(this).getIdentity();
 


### PR DESCRIPTION
This is mainly for compatibility with Things but I can imagine might fix something else as well. In any case this works the same as the Redirect and wont mess anything up