### PR TITLE
Architectury and yarn update

### DIFF
--- a/common/src/main/java/draylar/identity/command/IdentityCommand.java
+++ b/common/src/main/java/draylar/identity/command/IdentityCommand.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 public class IdentityCommand {
 
     public static void register() {
-        CommandRegistrationEvent.EVENT.register((dispatcher, b) -> {
+        CommandRegistrationEvent.EVENT.register((dispatcher, ctx, b) -> {
             LiteralCommandNode<ServerCommandSource> rootNode = CommandManager
                     .literal("identity")
                     .requires(source -> source.hasPermissionLevel(2))

--- a/common/src/main/java/draylar/identity/mixin/PiglinBruteBrainMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/PiglinBruteBrainMixin.java
@@ -23,7 +23,7 @@ public class PiglinBruteBrainMixin {
      * This mixin modifies the search logic to exclude players disguised as anything besides a Wither Skeleton or Wither.
      */
     @Overwrite
-    private static Optional<? extends LivingEntity> method_30249(AbstractPiglinEntity abstractPiglinEntity, MemoryModuleType<? extends LivingEntity> memoryModuleType) {
+    private static Optional<? extends LivingEntity> getTargetIfInRange(AbstractPiglinEntity abstractPiglinEntity, MemoryModuleType<? extends LivingEntity> memoryModuleType) {
         return abstractPiglinEntity.getBrain().getOptionalMemory(memoryModuleType).filter((livingEntity) -> {
             if(livingEntity instanceof PlayerEntity player) {
                 LivingEntity identity = PlayerIdentity.getIdentity(player);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Base Versions
-minecraft_version=1.19
+minecraft_version=1.19.1
 archives_base_name=identity
-mod_version=2.4.0
+mod_version=2.4.1
 maven_group=dev.draylar
 
 # Loader Versions
-fabric_loader_version=0.14.6
-fabric_api_version=0.53.4+1.18.2
-yarn_mappings=1.19+build.4
-forge_version=41.0.62
+fabric_loader_version=0.14.8
+fabric_api_version=0.58.5+1.19.1
+yarn_mappings=1.19.1+build.5
+forge_version=42.0.1
 
 # Dependency Versions
-architectury_version=5.7.28
+architectury_version=6.0.34


### PR DESCRIPTION
Addressing the many crash reports about the 1.19.1 version of the mod. Architectury changed a parameter for the lambda that register commands, so the current version explodes when the method is called.

https://github.com/architectury/architectury-api/commit/b316dde8ba586cdd786555babec5c99a5ee6987a#diff-9c56954883766aecb65a871be16628ceb5758ac25c00150b1a86c99555b74c6c