### PR TITLE
Fix PiglinBruteBrainMixin concerns [1.18.2]

### DIFF
--- a/common/src/main/java/draylar/identity/mixin/PiglinBruteBrainMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/PiglinBruteBrainMixin.java
@@ -2,16 +2,16 @@ package draylar.identity.mixin;
 
 import draylar.identity.api.PlayerIdentity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.ai.brain.MemoryModuleType;
 import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.mob.AbstractPiglinEntity;
 import net.minecraft.entity.mob.PiglinBruteBrain;
 import net.minecraft.entity.mob.WitherSkeletonEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-
-import java.util.Optional;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Group;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PiglinBruteBrain.class)
 public class PiglinBruteBrainMixin {
@@ -19,21 +19,31 @@ public class PiglinBruteBrainMixin {
     /**
      * @author Draylar
      *
-     * @reason method_30249 searches for a nearby player to aggro on.
+     * @reason method_30255 is the desugared lambda used by method_30249 that searches for a nearby player to aggro on.
      * This mixin modifies the search logic to exclude players disguised as anything besides a Wither Skeleton or Wither.
+     * We target fabric and forge separately due to arch not being able to find the backed methods of the targeted lambdas
      */
-    @Overwrite
-    private static Optional<? extends LivingEntity> method_30249(AbstractPiglinEntity abstractPiglinEntity, MemoryModuleType<? extends LivingEntity> memoryModuleType) {
-        return abstractPiglinEntity.getBrain().getOptionalMemory(memoryModuleType).filter((livingEntity) -> {
-            if(livingEntity instanceof PlayerEntity player) {
-                LivingEntity identity = PlayerIdentity.getIdentity(player);
+    @Group(name = "method_30249FilterLambda", min = 1, max = 1)
+    @Inject( method = "method_30255", at = @At("HEAD"), expect = 0, cancellable = true)
+    private static void identity$method_30249FilterLambdaIntermediary(AbstractPiglinEntity abstractPiglinEntity, LivingEntity livingEntity, CallbackInfoReturnable<Boolean> cir) {
+        if(livingEntity instanceof PlayerEntity player) {
+            LivingEntity identity = PlayerIdentity.getIdentity(player);
 
-                if(identity != null && !(identity instanceof WitherSkeletonEntity) && !(identity instanceof WitherEntity)) {
-                    return false;
-                }
+            if(identity != null && !(identity instanceof WitherSkeletonEntity) && !(identity instanceof WitherEntity)) {
+                cir.setReturnValue(false);
             }
+        }
+    }
 
-            return livingEntity.isInRange(abstractPiglinEntity, 12.0D);
-        });
+    @Group(name = "method_30249FilterLambda", min = 1, max = 1)
+    @Inject(method = "m_35106_", at = @At("HEAD"), remap = false, expect = 0, cancellable = true)
+    private static void identity$method_30249FilterLambdaSRG(AbstractPiglinEntity abstractPiglinEntity, LivingEntity livingEntity, CallbackInfoReturnable<Boolean> cir) {
+        if(livingEntity instanceof PlayerEntity player) {
+            LivingEntity identity = PlayerIdentity.getIdentity(player);
+
+            if(identity != null && !(identity instanceof WitherSkeletonEntity) && !(identity instanceof WitherEntity)) {
+                cir.setReturnValue(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #488 

The mixin before was using an Overwrite which causes concerns for other mods wanting to influence the behavior of the method (known as getTargetIfWithinRange on mojmaps). We now inject directly into the backing method of the filter lambda seen in the original method. This also fixes safety of other developers aiming to AW/AT the method to public in their own mods, as overwrite disallows this.

Tested it in production of both fabric and forge environments.

See edited javadoc for more info on the change implementation.