### PR TITLE
Remove link to Hastebin in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,4 +11,4 @@ assignees: ''
 *A description of what you expected to happen and what actually happened.*
 
 **Game log:**
-*Upload your game log through [hastebin](https://hastebin.com/) and provide the link. Do not paste the link directly into the submission box or comments.*
+*Upload your game log through [GitHub Gist](https://gist.github.com/) and provide the link. Do not paste the file or its contents directly into the submission box or comments.*


### PR DESCRIPTION
The [Hastebin](https://hastebin.com/) website is known to only keep pastes for a couple of days, while other websites, including but not limited to GitHub's own Gist service, keep pastes for much longer or indefinitely.

Same as https://github.com/Draylar/identity/pull/459, but applied to the new default branch.