### PR TITLE
Fixed a bug with cancelAirIncrement

### DIFF
--- a/common/src/main/java/draylar/identity/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/draylar/identity/mixin/LivingEntityMixin.java
@@ -62,25 +62,6 @@ public abstract class LivingEntityMixin extends Entity implements NearbySongAcce
     }
 
     @Redirect(
-            method = "baseTick",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;setAir(I)V", ordinal = 2)
-    )
-    private void cancelAirIncrement(LivingEntity livingEntity, int air) {
-        // Aquatic creatures should not regenerate breath on land
-        if ((Object) this instanceof PlayerEntity player) {
-            LivingEntity identity = PlayerIdentity.getIdentity(player);
-
-            if (identity != null) {
-                if (Identity.isAquatic(identity)) {
-                    return;
-                }
-            }
-        }
-
-        this.setAir(this.getNextAirOnLand(this.getAir()));
-    }
-
-    @Redirect(
             method = "travel",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;hasStatusEffect(Lnet/minecraft/entity/effect/StatusEffect;)Z", ordinal = 0)
     )

--- a/fabric/src/main/java/draylar/identity/fabric/mixin/LivingEntityMixin.java
+++ b/fabric/src/main/java/draylar/identity/fabric/mixin/LivingEntityMixin.java
@@ -1,0 +1,40 @@
+package draylar.identity.mixin;
+
+import draylar.identity.Identity;
+import draylar.identity.api.PlayerIdentity;
+import net.minecraft.entity.*;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin extends Entity {
+
+    @Shadow
+    protected abstract int getNextAirOnLand(int air);
+
+    protected LivingEntityMixin(EntityType<?> type, World world) {
+        super(type, world);
+    }
+
+    @Redirect(
+            method = "baseTick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;setAir(I)V", ordinal = 2)
+    )
+    private void cancelAirIncrement(LivingEntity livingEntity, int air) {
+        // Aquatic creatures should not regenerate breath on land
+        if ((Object) this instanceof PlayerEntity player) {
+            LivingEntity identity = PlayerIdentity.getIdentity(player);
+
+            if (identity != null) {
+                if (Identity.isAquatic(identity)) {
+                    return;
+                }
+            }
+        }
+
+        this.setAir(this.getNextAirOnLand(this.getAir()));
+    }
+}

--- a/fabric/src/main/resources/identity-fabric.mixins.json
+++ b/fabric/src/main/resources/identity-fabric.mixins.json
@@ -4,6 +4,7 @@
   "package": "draylar.identity.fabric.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "LivingEntityMixin",
     "WitherEntityMixin"
   ],
   "client": [

--- a/forge/src/main/java/draylar/identity/forge/WalkersForgeEventHandler.java
+++ b/forge/src/main/java/draylar/identity/forge/WalkersForgeEventHandler.java
@@ -1,0 +1,27 @@
+package tocraft.walkers.forge;
+
+import net.minecraft.entity.*;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.event.entity.living.LivingBreatheEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import draylar.identity.Identity;
+import draylar.identity.api.PlayerIdentity;
+
+@Mod.EventBusSubscriber(modid = "identity")
+public class WalkersForgeEventHandler {
+
+	@SubscribeEvent
+	public static void livingBreath(LivingBreatheEvent event) {
+		if (event.getEntity() instanceof PlayerEntity) {
+			LivingEntity identity = PlayerIdentity.getIdentity((PlayerEntity) event.getEntity());
+
+			if (identity != null) {
+				if (Identity.isAquatic(identity)) {
+					event.setCanBreathe(false);
+
+				}
+			}
+		}
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ maven_group=dev.draylar
 fabric_loader_version=0.14.21
 fabric_api_version=0.84.0+1.20.1
 yarn_mappings=1.20.1+build.8
-forge_version=47.0.43
+forge_version=47.1.43
 
 # Dependency Versions
 architectury_version=9.0.8


### PR DESCRIPTION
Since forge introduced the LivingBreathEvent and the LivingDrownEvent, `cancelAirIncrement` in the LivingEntityMixin didn't work for Forge 47.1.7+. This is fixed now.

This fixes #562 #566 #580 #590 #596 and probalby some other, too,