### PR TITLE
1.20.1 Crash fix

### DIFF
--- a/common/src/main/resources/identity.mixins.json
+++ b/common/src/main/resources/identity.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "draylar.identity.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ActiveTargetGoalMixin",
     "CreeperEntityMixin",

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[37,)"
+loaderVersion = "[47,)"
 #issueTrackerURL = ""
 license = "MIT"
 
@@ -16,20 +16,20 @@ Play as your favorite entities!
 [[dependencies.identity]]
 modId = "forge"
 mandatory = true
-versionRange = "[37,)"
+versionRange = "[47,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.identity]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.17.1,)"
+versionRange = "[1.20.1,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.identity]]
 modId = "architectury"
 mandatory = true
-versionRange = "[2.3.23,)"
+versionRange = "[9.1.13,)"
 ordering = "AFTER"
 side = "BOTH"

--- a/forge/src/main/resources/identity-forge.mixins.json
+++ b/forge/src/main/resources/identity-forge.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "draylar.identity.forge.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "WitherEntityMixin"
   ],

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "Identity",
-    "pack_format": 6
+    "pack_format": 15
   }
 }


### PR DESCRIPTION
> I think I know how to fix it. in the file that Anubiyo posted, change all the 37's to 47, the version range to 1.20.1 for identity dependencies, and the architectury dependencies to the latest 1.20.1 version of architectury. In forge/src/main/resources/pack.mcmeta, change the pack format to 15. Then you recompile it and it should work I think? I might be wrong (probably am).
> 
> Edit: In forge/src/main/resources/identity-forge.mixins.json and common/src/main/resources/identity.mixins.json change JAVA_16 to JAVA_17
> Edit Edit: I'm just gonna link this into a new issue with the solution, and post any updates there. 

 _Originally posted by @NugglinGaming in [#668](https://github.com/Draylar/identity/issues/668#issuecomment-2784549055)_

I'll be posting any extra findings here, and feel free to help me out here.
This is my fix